### PR TITLE
Limit tested Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,6 @@ sudo: false
 
 # Python versions to test
 python:
-  - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
 


### PR DESCRIPTION
Ubuntu 18.10 (where I'm building images now) is 3.5.  Removing anything
before that.