### PR TITLE
S3 storage

### DIFF
--- a/extras/docker/apache/Dockerfile
+++ b/extras/docker/apache/Dockerfile
@@ -44,9 +44,10 @@ RUN a2dissite 000-default.conf \
 # Configure cron
 COPY ${DOCKER_DIR}/crontab /etc/cron.d/wger
 COPY ${DOCKER_DIR}/venvwrapper /home/wger/venvwrapper
+COPY ${DOCKER_DIR}/entrypoint.sh /home/wger/entrypoint.sh
 
 RUN chmod 0644 /etc/cron.d/wger \
-  && chmod +x /home/wger/venvwrapper \
+  && chmod +x /home/wger/venvwrapper /home/wger/entrypoint.sh \
   && touch /var/log/cron.log
 
 COPY --chown=wger:www-data . /home/wger/src
@@ -86,5 +87,4 @@ RUN chmod o+w -R ~/db/ \
 
 USER root
 
-ENTRYPOINT ["/usr/sbin/apache2ctl"]
-CMD ["-D", "FOREGROUND"]
+ENTRYPOINT ["/home/wger/entrypoint.sh"]

--- a/extras/docker/apache/entrypoint.sh
+++ b/extras/docker/apache/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+if [ "${USE_S3}" = "TRUE" ]; then
+  python manage.py collectstatic --no-input
+fi
+
+/usr/sbin/apache2ctl -D FOREGROUND

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ Django>=1.11,<2.0
 django_compressor==2.2
 django_extensions>=2.1
 django-sorted-m2m>=2.0
+django-storages>=1.7
 easy-thumbnails==2.6
 icalendar==4.0.3
 invoke==0.17
@@ -21,6 +22,7 @@ matplotlib>=3.1
 requests
 setuptools>=18.5
 sphinx
+boto3
 
 # Production
 psycopg2

--- a/wger/core/templates/template.html
+++ b/wger/core/templates/template.html
@@ -117,13 +117,15 @@
                 {#                                         #}
                 <div class="btn-group">
                     <button type="button" class="btn btn-primary dropdown-toggle btn-xs" data-toggle="dropdown">
-                        <img src="/static/images/icons/flag-{{language.short_name}}.svg"
+                      {% with 'images/icons/flag-'|add:language.short_name|add:'.svg' as flagname %}
+                      <img src="{% static flagname %}"
                              width="18"
                              height="11"
                              alt="{% trans language.full_name %}"
                              title="{% trans language.full_name %}"
                              style="border: 1px solid #151515;">
                         {{language.full_name}} <span class="caret"></span>
+                      {% endwith %}
                     </button>
                     <ul class="dropdown-menu" role="menu">
                         {% for language in languages %}

--- a/wger/settings_global.py
+++ b/wger/settings_global.py
@@ -45,6 +45,7 @@ INSTALLED_APPS = (
     'django.contrib.sites',
     'django.contrib.staticfiles',
     'django_extensions',
+    'storages',
 
     # Uncomment the next line to enable the admin:
     'django.contrib.admin',
@@ -305,12 +306,30 @@ THUMBNAIL_ALIASES = {
     },
 }
 
+STATIC_ROOT = ''
+USE_S3 = os.getenv('USE_S3') == 'TRUE'
+
+if USE_S3:
+    # aws settings
+    AWS_ACCESS_KEY_ID = os.getenv('AWS_ACCESS_KEY_ID')
+    AWS_SECRET_ACCESS_KEY = os.getenv('AWS_SECRET_ACCESS_KEY')
+    AWS_STORAGE_BUCKET_NAME = os.getenv('AWS_STORAGE_BUCKET_NAME')
+    AWS_DEFAULT_ACL = 'public-read'
+    AWS_S3_CUSTOM_DOMAIN = os.getenv('WGER_CDN_DOMAIN')
+    AWS_S3_OBJECT_PARAMETERS = {'CacheControl': 'max-age=86400'}
+    # s3 static settings
+    AWS_LOCATION = 'static'
+    STATIC_URL = f'https://{AWS_S3_CUSTOM_DOMAIN}/{AWS_LOCATION}/'
+    STATICFILES_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
+    COMPRESS_URL = STATIC_URL
+    COMPRESS_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
+else:
+    STATIC_URL = '/static/'
+
 
 #
 # Django compressor
 #
-STATIC_ROOT = ''
-STATIC_URL = '/static/'
 
 # The default is not DEBUG, override if needed
 # COMPRESS_ENABLED = True

--- a/wger/settings_global.py
+++ b/wger/settings_global.py
@@ -319,7 +319,7 @@ if USE_S3:
     AWS_S3_OBJECT_PARAMETERS = {'CacheControl': 'max-age=86400'}
     # s3 static settings
     AWS_LOCATION = 'static'
-    STATIC_URL = f'https://{AWS_S3_CUSTOM_DOMAIN}/{AWS_LOCATION}/'
+    STATIC_URL = 'https://%s/%s/' % (AWS_S3_CUSTOM_DOMAIN, AWS_LOCATION)
     STATICFILES_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
     COMPRESS_URL = STATIC_URL
     COMPRESS_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'


### PR DESCRIPTION
Use django-storages to serve static assets from S3.  Enabled by setting the `USE_S3` environmental variable to `TRUE`.